### PR TITLE
feat: mount env file in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./.env:/app/.env"
 
   redis:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   lab-framework:
-    build:
-      dockerfile: ./Dockerfile
+    image: ghcr.io/codygreen/lab-framework-demo-lab-framework:sha-9916438
+    # build:
+    #   dockerfile: ./Dockerfile
     restart: always
     ports:
       - "3000:3000"
@@ -14,8 +15,9 @@ services:
       - "./.env:/app/.env"
 
   redis:
-    build:
-      dockerfile: ./Dockerfile.redis
+    image: ghcr.io/codygreen/lab-framework-demo-redis:sha-9916438
+    # build:
+    #   dockerfile: ./Dockerfile.redis
     restart: always
     ports:
       - "6379:6379"


### PR DESCRIPTION
Closes #64 

Note: [this](https://blog.roberthallam.org/2021/11/why-isnt-my-docker-bind-mounted-file-updating-from-host-to-container-when-i-make-changes-with-vim/) is an issue when editing the `.env` file in vi/vim. Added the following to the lab blueprint to change this behavior:

```shell
tee ~/.vimrc > /dev/null <<'EOF'
set backupcopy yes
EOF
```