### PR TITLE
fix: flow down missing tlsComponent vars to APICheck, remove http fro…

### DIFF
--- a/src/app/[doc]/page.js
+++ b/src/app/[doc]/page.js
@@ -1,7 +1,6 @@
 import { getMdxContent } from "@/lib/mdxUtils"
 
 export default async function Page({ params }) {
-
   const { content, frontmatter } = await getMdxContent(params.doc)
   return (
     <>

--- a/src/app/components/api-check.js
+++ b/src/app/components/api-check.js
@@ -21,6 +21,7 @@ import { APIBase } from "@/lib/api-base"
  *    path="/example-path" 
  *    targetStatusCode={200} 
  *    url="https://api.example.com" 
+ *    tlsComponent={false}
  *  />
  */
 export function APICheck({

--- a/src/lib/api-base.js
+++ b/src/lib/api-base.js
@@ -16,6 +16,7 @@ import { useState } from "react";
  * @param {string} [props.path="/"] - The path to append to the URL for the API check.
  * @param {number} [props.targetStatusCode=200] - The expected HTTP status code from the API check.
  * @param {string} [props.url=null] - The URL to check.
+ * @param {boolean} [props.tlsComponent=false] - If a component name is specified, use TLS (https) to connect to the component. Default is no TLS (http).
  * 
  * @returns {JSX.Element} The rendered component.
  */
@@ -26,7 +27,8 @@ export function APIBase({
   searchString = null,
   path = "/",
   targetStatusCode = 200,
-  url = null
+  url = null,
+  tlsComponent = false
 }) {
   const [state, setState] = useState({ status: null, error: null });
 
@@ -38,7 +40,7 @@ export function APIBase({
    */
   const handleCheck = async () => {
     try {
-      await checkAPI({ componentName, headerName, headerValue, searchString, path, targetStatusCode, url });
+      await checkAPI({ componentName, headerName, headerValue, searchString, path, targetStatusCode, url, tlsComponent });
       setState({ status: true, error: null });
     } catch (error) {
       const errorMessage = "The API check failed"

--- a/src/lib/check-api.js
+++ b/src/lib/check-api.js
@@ -9,7 +9,7 @@ import { fetchRedisVariable } from "./redis";
  * constructs the base URL and port, and returns the full URL.
  * 
  * @param {string} name - The URL or component name to check.
- * @param {boolean} [tls] - A True value will use TLS (https) to connect to the component. A False value is no TLS (http).
+ * @param {boolean} tls - A True value will use TLS (https) to connect to the component. A False value is no TLS (http).
  * @returns {Promise<string>} - The full URL of the component.
  * @throws {Error} - Throws an error if petname or component data is missing or invalid.
  */
@@ -22,7 +22,7 @@ async function getComponentUrl(name, tls) {
   const port = componentData?.ports?.host;
   if (port) return `${protocol}://host.docker.internal:${port}`;
 
-  return componentData?.url || `${protocol}://${componentName}`;
+  return `${protocol}://${componentData?.host}`;
 }
 
 /**

--- a/src/lib/containers.js
+++ b/src/lib/containers.js
@@ -77,7 +77,7 @@ async function handleDockerClose(command, code, containerName, stdoutData, port)
       return stdoutData;
     case "run":
       await setRedisVariable(`components:${containerName}`,
-        { status: "running", url: `http://${containerName}`, ...(port && { ports: port }) });
+        { status: "running", host: containerName, ...(port && { ports: port }) });
       break;
     case "rm":
       await removeRedisVariable(`components:${containerName}`);

--- a/src/lib/variables.js
+++ b/src/lib/variables.js
@@ -13,11 +13,11 @@ import { fetchLabInfo, fetchUDFInfo } from "./udf";
  * @param {string} - a name
  * @return {string} - a unique and normalized component name
  */
-export async function getComponentName(name){
+export async function getComponentName(name) {
     try {
         const petname = await getPetname();
         return petname + "-" + name.replace(/[^a-zA-Z0-9 ]/g, "").replace(/ /g, "-").toLowerCase();
-    } catch(error) {
+    } catch (error) {
         throw new Error("Error getting component name: ", error.message)
     }
 }
@@ -53,7 +53,7 @@ export async function getPetname() {
         petname = petData[petnameKey];
         await setRedisVariable(petnameKey, petname);
         process.env["PETNAME"] = petname;
-    return petname;
+        return petname;
     } catch (error) {
         console.error("Error fetching pet name:", error);
     }


### PR DESCRIPTION
flow down missing tlsComponent vars to APICheck
remove http from component url. 
Store only hostname in redis component record, as it isn't possible to assume an http or https URL from the docker container.

Closes #176 

Addresses incomplete TLS implementation from #123 