### PR TITLE
fix: add support for inline code blocks in markdown

### DIFF
--- a/src/app/components/codeblock.js
+++ b/src/app/components/codeblock.js
@@ -5,15 +5,16 @@ import { getVariable } from "@/lib/variables";
 import { CodeBlockCopy } from "@/app/components/codeblock-copy";
 
 /**
- * A React component that renders a syntax-highlighted code block with the ability to copy its content.
+ * A React component that renders a syntax-highlighted code block with the ability to copy its content and optional variable replacement.
  *
- * @param {Object} props - The component props.
- * @param {string} props.className - The class name indicating the language of the code block.
- * @param {string} props.children - The code block content.
+ * @param {Object} props - The properties object.
+ * @param {string} props.className - The CSS class name for the code block.
+ * @param {string} props.children - The code block content containing placeholders.
+ * @param {boolean} props.isBlock - Flag indicating if the code block should be rendered as a block element.
+ * @param {...Object} props - Additional properties to be passed to the code block.
  * @returns {JSX.Element} - The rendered code block component.
  */
-export async function CodeBlock({ className, children }) {
-  const language = className?.replace("language-", "") || "javascript";
+export async function CodeBlock({ className, children, isBlock, ...props }) {
 
   /**
    * Fetches the value of a variable from the server.
@@ -34,10 +35,10 @@ export async function CodeBlock({ className, children }) {
    * @returns {Promise<string>} - A promise that resolves to the processed code block content.
    */
   const processChildren = async (children) => {
-    if(!children || typeof children !== "string") {
-      console.error('No children or children is not a string');
+    if (!children || typeof children !== "string") {
+      console.error("No children or children is not a string");
       return;
-    } 
+    }
     const regex = /{{(.*?)}}/g;
     let match;
     const promises = [];
@@ -60,10 +61,27 @@ export async function CodeBlock({ className, children }) {
 
   const childData = await processChildren(children);
 
+  if (!isBlock) {
+    return (
+      <span className="text-solarized-light-gray bg-solarized-light-tan rounded-lg px-2 py-1">
+        <code {...props} >
+          {children}
+        </code>
+      </span>
+    );
+  }
+
+  const language = /language-(\w+)/.exec(className || "");
+
   return (
     <div className="relative bg-gray-800 rounded-lg">
-     <CodeBlockCopy>{childData}</CodeBlockCopy>
-      <SyntaxHighlighter language={language} style={solarizedlight}>
+      <CodeBlockCopy>{childData}</CodeBlockCopy>
+      <SyntaxHighlighter
+        style={solarizedlight}
+        PreTag="div"
+        language={language ? language[1] : null}
+        {...props}
+      >
         {childData}
       </SyntaxHighlighter>
     </div>

--- a/src/lib/mdxComponents.js
+++ b/src/lib/mdxComponents.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { APICheck } from "@/app/components/api-check";
 import { APIHeaderCheck } from "@/app/components/api-header-check";
 import { APIResponseCheck } from "@/app/components/api-response-check";
@@ -34,8 +35,18 @@ const MDXComponents = {
   h2: (props) => <h2 id={formatId(props.children)} {...props} />,
   h3: (props) => <h3 id={formatId(props.children)} {...props} />,
   h4: (props) => <h4 id={formatId(props.children)} {...props} />,
-  code: (props) => <CodeBlock {...props} />,
-  img: (props) => <ImageModalClient {...props} />
+  pre: ({ children }) => (
+    <pre>
+      {React.Children.map(children, child => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, { isBlock: true });
+        }
+        return child;
+      })}
+    </pre>
+  ),
+  code: CodeBlock,
+  img: ImageModalClient
 }
 
 export default MDXComponents

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,12 @@ module.exports = {
     "./src/lib/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "solarized-light-gray": "#657b83",
+        "solarized-light-tan": "#fdf6e3",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Closes #29 

![image](https://github.com/user-attachments/assets/05bc3ce3-e3ce-4c2b-9467-b0a186b0b5a5)
