### PR TITLE
use inline blob data for href instead of blob storage

### DIFF
--- a/src/app/components/download-item.js
+++ b/src/app/components/download-item.js
@@ -2,12 +2,10 @@
 
 export function DownloadItem({ item, fileName }) {
 
-  const file = new Blob([item], {
-    type: "text/plain"
-  });
+  const dataHref = `data:text/plain;charset=utf-8,${encodeURIComponent(item)}`
 
   return (
-    <a download={fileName} target="_blank" rel="noreferrer" href={URL.createObjectURL(file)} style={{
+    <a download={fileName} target="_blank" rel="noreferrer" href={dataHref} style={{
       textDecoration: "inherit",
       color: "inherit",
     }}>


### PR DESCRIPTION
Previous implementation wouldn't work in certain deployment environments, likely due to browser security settings